### PR TITLE
feat: harden request host derivation and add getHost option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,38 +60,47 @@ export const handler = createAPIGatewayV2RequestHandler({
 > It does not allow tree-shaking and will include all gateway adapters in your bundle.  
 > For optimal bundle size, always use the method specific to your gateway:
 
-### Request host & CSRF (`useRequestContextDomainName`)
+### Request host & CSRF (`getHost`)
 
 React Router derives the host used for its built-in cross-origin (CSRF) check on
 action requests from the constructed request URL (`new URL(request.url).host`),
-so it is important that the adapter builds that host from a trustworthy source.
+comparing it against the incoming `Origin` header. It is therefore important that
+the adapter builds that host from a source you trust.
 
-By default the adapters build the host from the client-supplied
-`x-forwarded-host` header (falling back to the `host` header). Set
-`useRequestContextDomainName: true` to instead use the AWS-provided
-`event.requestContext.domainName`, which cannot be influenced by the client:
+By default the adapters build the host from the `x-forwarded-host` header
+(falling back to the `host`/`Host` header). The resolved value is always
+sanitized (invalid characters stripped, port validated) before use.
+
+If the default forwarded host is not the host the browser actually sees, use the
+`getHost` option to derive it yourself. The most common case is a **Lambda
+Function URL behind CloudFront**: its `event.requestContext.domainName` is always
+the internal `*.lambda-url.<region>.on.aws` host (and cannot be overridden), so
+you must read the viewer host from a trusted header CloudFront forwards, such as
+`cloudfront-viewer-host`:
 
 ```javascript
 // lambda-handler.ts
 import * as build from "virtual:react-router/server-build";
-import { createAPIGatewayV2RequestHandler } from "@geostrategists/react-router-aws";
+import { createFunctionURLRequestHandler } from "@geostrategists/react-router-aws";
 
-export const handler = createAPIGatewayV2RequestHandler({
+export const handler = createFunctionURLRequestHandler({
   build,
-  useRequestContextDomainName: true,
+  getHost: (event) => event.headers["cloudfront-viewer-host"],
 });
 ```
 
-This option is supported by the API Gateway v1, API Gateway v2 and Lambda
-Function URL (buffered and streaming) handlers. It has no effect for the ALB
-handler, whose events carry no request-context domain name.
+`getHost` receives the (correctly typed) gateway event and may return a host
+string, or `undefined`/`null` to fall back to the default `x-forwarded-host`
+behavior. It is supported by all handlers (API Gateway v1, API Gateway v2, Lambda
+Function URL buffered & streaming, and ALB). For example, to prefer the
+API Gateway request-context domain name: `getHost: (event) => event.requestContext.domainName`.
 
 > [!NOTE]
-> To align with the upstream `@react-router/architect` adapter, this option
-> defaults to `false` for now but **will default to `true` in the next major
-> version**, after which the flag will be removed and the request-context domain
-> name will always be used. Set it explicitly if you rely on the current
-> `x-forwarded-host` behavior.
+> The default currently uses the `x-forwarded-host` header. To align with the
+> upstream `@react-router/architect` adapter, the default **will change to the
+> API Gateway request-context domain name (`event.requestContext.domainName`) in
+> the next major version**. Setups where that host is not the browser-facing host
+> (e.g. Function URLs behind CloudFront) should set `getHost` explicitly.
 
 ### Streaming support for Lambda Function URLs
 

--- a/README.md
+++ b/README.md
@@ -95,12 +95,17 @@ behavior. It is supported by all handlers (API Gateway v1, API Gateway v2, Lambd
 Function URL buffered & streaming, and ALB). For example, to prefer the
 API Gateway request-context domain name: `getHost: (event) => event.requestContext.domainName`.
 
-> [!NOTE]
-> The default currently uses the `x-forwarded-host` header. To align with the
-> upstream `@react-router/architect` adapter, the default **will change to the
-> API Gateway request-context domain name (`event.requestContext.domainName`) in
-> the next major version**. Setups where that host is not the browser-facing host
-> (e.g. Function URLs behind CloudFront) should set `getHost` explicitly.
+> [!IMPORTANT]
+> The default currently uses the `x-forwarded-host` header, which is
+> **client-controlled** and can be spoofed. Because that host drives React
+> Router's CSRF check, trusting it should be a deliberate choice. To make the
+> safe option the default (and to align with the upstream
+> `@react-router/architect` adapter), the default **will change to the
+> AWS-provided, non-spoofable request-context domain name
+> (`event.requestContext.domainName`) in the next major version**. After that,
+> relying on `x-forwarded-host` (or any other forwarded header) becomes an
+> explicit opt-in via `getHost`. Setups where the request-context host is not the
+> browser-facing host (e.g. Function URLs behind CloudFront) must set `getHost`.
 
 ### Streaming support for Lambda Function URLs
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,10 @@ it into a header, then read that header via `getHost`:
 ```javascript
 // CloudFront Function (viewer request): copy the viewer host into a custom header
 function handler(event) {
-  event.request.headers["x-viewer-host"] = { value: event.request.headers.host.value };
+  var host = event.request.headers.host;
+  if (host) {
+    event.request.headers["x-viewer-host"] = { value: host.value };
+  }
   return event.request;
 }
 ```

--- a/README.md
+++ b/README.md
@@ -60,6 +60,39 @@ export const handler = createAPIGatewayV2RequestHandler({
 > It does not allow tree-shaking and will include all gateway adapters in your bundle.  
 > For optimal bundle size, always use the method specific to your gateway:
 
+### Request host & CSRF (`useRequestContextDomainName`)
+
+React Router derives the host used for its built-in cross-origin (CSRF) check on
+action requests from the constructed request URL (`new URL(request.url).host`),
+so it is important that the adapter builds that host from a trustworthy source.
+
+By default the adapters build the host from the client-supplied
+`x-forwarded-host` header (falling back to the `host` header). Set
+`useRequestContextDomainName: true` to instead use the AWS-provided
+`event.requestContext.domainName`, which cannot be influenced by the client:
+
+```javascript
+// lambda-handler.ts
+import * as build from "virtual:react-router/server-build";
+import { createAPIGatewayV2RequestHandler } from "@geostrategists/react-router-aws";
+
+export const handler = createAPIGatewayV2RequestHandler({
+  build,
+  useRequestContextDomainName: true,
+});
+```
+
+This option is supported by the API Gateway v1, API Gateway v2 and Lambda
+Function URL (buffered and streaming) handlers. It has no effect for the ALB
+handler, whose events carry no request-context domain name.
+
+> [!NOTE]
+> To align with the upstream `@react-router/architect` adapter, this option
+> defaults to `false` for now but **will default to `true` in the next major
+> version**, after which the flag will be removed and the request-context domain
+> name will always be used. Set it explicitly if you rely on the current
+> `x-forwarded-host` behavior.
+
 ### Streaming support for Lambda Function URLs
 
 React Router and React allow you to stream responses from the server to the client, reducing the TTFB (time to first byte)

--- a/README.md
+++ b/README.md
@@ -82,11 +82,14 @@ yourself, typically with a CloudFront Function on the viewer request that copies
 it into a header, then read that header via `getHost`:
 
 ```javascript
-// CloudFront Function (viewer request): copy the viewer host into a custom header
+// CloudFront Function (viewer request): copy the viewer host into a custom header.
+// Always overwrite (or delete) it so a client can't spoof x-viewer-host.
 function handler(event) {
   var host = event.request.headers.host;
   if (host) {
     event.request.headers["x-viewer-host"] = { value: host.value };
+  } else {
+    delete event.request.headers["x-viewer-host"];
   }
   return event.request;
 }

--- a/README.md
+++ b/README.md
@@ -73,10 +73,21 @@ sanitized (invalid characters stripped, port validated) before use.
 
 If the default forwarded host is not the host the browser actually sees, use the
 `getHost` option to derive it yourself. The most common case is a **Lambda
-Function URL behind CloudFront**: its `event.requestContext.domainName` is always
-the internal `*.lambda-url.<region>.on.aws` host (and cannot be overridden), so
-you must read the viewer host from a trusted header CloudFront forwards, such as
-`cloudfront-viewer-host`:
+Function URL behind CloudFront**: `event.requestContext.domainName` is always the
+internal `*.lambda-url.<region>.on.aws` host (and cannot be overridden), and
+CloudFront does not forward the viewer's host to the origin — the managed
+`AllViewerExceptHostHeader` policy (recommended for Function URL / API Gateway
+origins) sets `Host` to the origin domain. So you must forward the viewer host
+yourself, typically with a CloudFront Function on the viewer request that copies
+it into a header, then read that header via `getHost`:
+
+```javascript
+// CloudFront Function (viewer request): copy the viewer host into a custom header
+function handler(event) {
+  event.request.headers["x-viewer-host"] = { value: event.request.headers.host.value };
+  return event.request;
+}
+```
 
 ```javascript
 // lambda-handler.ts
@@ -85,9 +96,12 @@ import { createFunctionURLRequestHandler } from "@geostrategists/react-router-aw
 
 export const handler = createFunctionURLRequestHandler({
   build,
-  getHost: (event) => event.headers["cloudfront-viewer-host"],
+  getHost: (event) => event.headers["x-viewer-host"],
 });
 ```
+
+(If you copy the viewer host into `x-forwarded-host` instead, the default already
+picks it up and `getHost` isn't needed.)
 
 `getHost` receives the (correctly typed) gateway event and may return a host
 string, or `undefined`/`null` to fall back to the default `x-forwarded-host`

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "prepack": "pnpm build"
   },
   "devDependencies": {
-    "@react-router/node": "^7.9.1",
+    "@react-router/node": "^7.18.0",
     "@types/aws-lambda": "^8.10.152",
     "@types/node": "^22.19.21",
     "@types/react": "^19",
@@ -58,15 +58,15 @@
     "oxlint": "^1.69.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "react-router": "^7.9.1",
+    "react-router": "^7.18.0",
     "rimraf": "^6.1.2",
     "tsdown": "^0.22.2",
     "typescript": "^5.9.3",
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "@react-router/node": "^7.9.1",
-    "react-router": "^7.9.1"
+    "@react-router/node": "^7.18.0",
+    "react-router": "^7.18.0"
   },
   "engines": {
     "node": ">=22"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     devDependencies:
       '@react-router/node':
-        specifier: ^7.9.1
+        specifier: ^7.18.0
         version: 7.18.0(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
       '@types/aws-lambda':
         specifier: ^8.10.152
@@ -42,7 +42,7 @@ importers:
         specifier: ^19.1.1
         version: 19.2.7(react@19.2.7)
       react-router:
-        specifier: ^7.9.1
+        specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       rimraf:
         specifier: ^6.1.2

--- a/src/adapters/api-gateway-v1.ts
+++ b/src/adapters/api-gateway-v1.ts
@@ -4,9 +4,16 @@ import { URLSearchParams } from "url";
 
 import { isBinaryType } from "../binaryTypes";
 import type { ReactRouterAdapter } from "./index";
+import { resolveHost } from "./host";
 
-function createReactRouterRequestAPIGatewayV1(event: APIGatewayProxyEvent): Request {
-  const host = event.headers["x-forwarded-host"] || event.headers.Host;
+function createReactRouterRequestAPIGatewayV1(
+  event: APIGatewayProxyEvent,
+  useRequestContextDomainName = false,
+): Request {
+  const rawHost = useRequestContextDomainName
+    ? event.requestContext.domainName || event.headers.Host
+    : event.headers["x-forwarded-host"] || event.headers.Host;
+  const host = resolveHost(rawHost);
   const scheme = event.headers["x-forwarded-proto"] || "http";
 
   const rawQueryString = new URLSearchParams(event.queryStringParameters as Record<string, string>).toString();

--- a/src/adapters/api-gateway-v1.ts
+++ b/src/adapters/api-gateway-v1.ts
@@ -4,15 +4,13 @@ import { URLSearchParams } from "url";
 
 import { isBinaryType } from "../binaryTypes";
 import { resolveHost } from "./host";
-import type { ReactRouterAdapter } from "./index";
+import type { GetHostFunction, ReactRouterAdapter } from "./index";
 
 function createReactRouterRequestAPIGatewayV1(
   event: APIGatewayProxyEvent,
-  useRequestContextDomainName = false,
+  getHost?: GetHostFunction<APIGatewayProxyEvent>,
 ): Request {
-  const rawHost = useRequestContextDomainName
-    ? event.requestContext.domainName || event.headers.Host
-    : event.headers["x-forwarded-host"] || event.headers.Host;
+  const rawHost = getHost?.(event) ?? (event.headers["x-forwarded-host"] || event.headers.Host);
   const host = resolveHost(rawHost);
   const scheme = event.headers["x-forwarded-proto"] || "http";
 

--- a/src/adapters/api-gateway-v1.ts
+++ b/src/adapters/api-gateway-v1.ts
@@ -3,8 +3,8 @@ import type { APIGatewayProxyEvent, APIGatewayProxyEventHeaders, APIGatewayProxy
 import { URLSearchParams } from "url";
 
 import { isBinaryType } from "../binaryTypes";
-import type { ReactRouterAdapter } from "./index";
 import { resolveHost } from "./host";
+import type { ReactRouterAdapter } from "./index";
 
 function createReactRouterRequestAPIGatewayV1(
   event: APIGatewayProxyEvent,

--- a/src/adapters/api-gateway-v2.ts
+++ b/src/adapters/api-gateway-v2.ts
@@ -7,15 +7,13 @@ import type {
 
 import { isBinaryType } from "../binaryTypes";
 import { resolveHost } from "./host";
-import type { ReactRouterAdapter } from "./index";
+import type { GetHostFunction, ReactRouterAdapter } from "./index";
 
 export function createReactRouterRequestAPIGateywayV2(
   event: APIGatewayProxyEventV2,
-  useRequestContextDomainName = false,
+  getHost?: GetHostFunction<APIGatewayProxyEventV2>,
 ): Request {
-  const rawHost = useRequestContextDomainName
-    ? event.requestContext.domainName || event.headers.host
-    : event.headers["x-forwarded-host"] || event.headers.host;
+  const rawHost = getHost?.(event) ?? (event.headers["x-forwarded-host"] || event.headers.host);
   const host = resolveHost(rawHost);
   const search = event.rawQueryString.length ? `?${event.rawQueryString}` : "";
   const scheme = event.headers["x-forwarded-proto"] || "http";

--- a/src/adapters/api-gateway-v2.ts
+++ b/src/adapters/api-gateway-v2.ts
@@ -6,8 +6,8 @@ import type {
 } from "aws-lambda";
 
 import { isBinaryType } from "../binaryTypes";
-import type { ReactRouterAdapter } from "./index";
 import { resolveHost } from "./host";
+import type { ReactRouterAdapter } from "./index";
 
 export function createReactRouterRequestAPIGateywayV2(
   event: APIGatewayProxyEventV2,

--- a/src/adapters/api-gateway-v2.ts
+++ b/src/adapters/api-gateway-v2.ts
@@ -7,9 +7,16 @@ import type {
 
 import { isBinaryType } from "../binaryTypes";
 import type { ReactRouterAdapter } from "./index";
+import { resolveHost } from "./host";
 
-export function createReactRouterRequestAPIGateywayV2(event: APIGatewayProxyEventV2): Request {
-  const host = event.headers["x-forwarded-host"] || event.headers.host;
+export function createReactRouterRequestAPIGateywayV2(
+  event: APIGatewayProxyEventV2,
+  useRequestContextDomainName = false,
+): Request {
+  const rawHost = useRequestContextDomainName
+    ? event.requestContext.domainName || event.headers.host
+    : event.headers["x-forwarded-host"] || event.headers.host;
+  const host = resolveHost(rawHost);
   const search = event.rawQueryString.length ? `?${event.rawQueryString}` : "";
   const scheme = event.headers["x-forwarded-proto"] || "http";
 

--- a/src/adapters/application-load-balancer.ts
+++ b/src/adapters/application-load-balancer.ts
@@ -4,13 +4,11 @@ import { URLSearchParams } from "url";
 
 import { isBinaryType } from "../binaryTypes";
 import { resolveHost } from "./host";
-import type { ReactRouterAdapter } from "./index";
+import type { GetHostFunction, ReactRouterAdapter } from "./index";
 
-// ALB events carry no trusted request-context domain name, so
-// `useRequestContextDomainName` does not apply here and is ignored.
-function createReactRouterRequestALB(event: ALBEvent): Request {
+function createReactRouterRequestALB(event: ALBEvent, getHost?: GetHostFunction<ALBEvent>): Request {
   const headers = event?.headers || {};
-  const host = resolveHost(headers["x-forwarded-host"] || headers.Host);
+  const host = resolveHost(getHost?.(event) ?? (headers["x-forwarded-host"] || headers.Host));
   const scheme = headers["x-forwarded-proto"] || "http";
 
   const rawQueryString = new URLSearchParams(event.queryStringParameters as Record<string, string>).toString();

--- a/src/adapters/application-load-balancer.ts
+++ b/src/adapters/application-load-balancer.ts
@@ -4,10 +4,13 @@ import { URLSearchParams } from "url";
 
 import { isBinaryType } from "../binaryTypes";
 import type { ReactRouterAdapter } from "./index";
+import { resolveHost } from "./host";
 
+// ALB events carry no trusted request-context domain name, so
+// `useRequestContextDomainName` does not apply here and is ignored.
 function createReactRouterRequestALB(event: ALBEvent): Request {
   const headers = event?.headers || {};
-  const host = headers["x-forwarded-host"] || headers.Host;
+  const host = resolveHost(headers["x-forwarded-host"] || headers.Host);
   const scheme = headers["x-forwarded-proto"] || "http";
 
   const rawQueryString = new URLSearchParams(event.queryStringParameters as Record<string, string>).toString();

--- a/src/adapters/application-load-balancer.ts
+++ b/src/adapters/application-load-balancer.ts
@@ -3,8 +3,8 @@ import type { ALBEvent, ALBEventHeaders, ALBResult } from "aws-lambda";
 import { URLSearchParams } from "url";
 
 import { isBinaryType } from "../binaryTypes";
-import type { ReactRouterAdapter } from "./index";
 import { resolveHost } from "./host";
+import type { ReactRouterAdapter } from "./index";
 
 // ALB events carry no trusted request-context domain name, so
 // `useRequestContextDomainName` does not apply here and is ignored.

--- a/src/adapters/host.ts
+++ b/src/adapters/host.ts
@@ -1,0 +1,19 @@
+/**
+ * Resolves the host used to build the `Request` URL from a raw host value
+ * (e.g. an `x-forwarded-host`/`host` header or an API Gateway domain name).
+ *
+ * React Router derives the host for its built-in cross-origin (CSRF) check on
+ * action requests from `new URL(request.url).host`, so the host constructed
+ * here must be trustworthy and well-formed. Invalid characters are stripped and
+ * the port is validated to avoid constructing a malformed URL (or leaking a
+ * spoofed host) from a garbled header value.
+ *
+ * Mirrors the hardening done by the upstream `@react-router/architect` adapter.
+ */
+export function resolveHost(rawHost: string | undefined | null): string {
+  const [rawHostname = "", portStr] = (rawHost ?? "").split(":");
+  const hostname = rawHostname.split(/[\\/?#@]/)[0] || "localhost";
+  const hostPort = Number.parseInt(portStr ?? "", 10);
+  const port = Number.isSafeInteger(hostPort) ? hostPort : undefined;
+  return `${hostname}${port ? `:${port}` : ""}`;
+}

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,7 +1,16 @@
 import type { Handler } from "aws-lambda";
 
+/**
+ * Resolves the raw host for the request URL from a Lambda event.
+ *
+ * Return `undefined`/`null` to fall back to the adapter default (the
+ * `x-forwarded-host` header, falling back to the `host`/`Host` header). The
+ * returned value is sanitized via {@link resolveHost} before use.
+ */
+export type GetHostFunction<E> = (event: E) => string | null | undefined;
+
 export interface ReactRouterAdapter<E, Ret, Res = void, H = Handler<E, Ret>> {
   wrapHandler: (handler: (event: E, res: Res) => Promise<Ret>) => H;
-  createReactRouterRequest: (event: E, useRequestContextDomainName?: boolean) => Request;
+  createReactRouterRequest: (event: E, getHost?: GetHostFunction<E>) => Request;
   sendReactRouterResponse: (nodeResponse: Response, response: Res) => Promise<Ret>;
 }

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -2,6 +2,6 @@ import type { Handler } from "aws-lambda";
 
 export interface ReactRouterAdapter<E, Ret, Res = void, H = Handler<E, Ret>> {
   wrapHandler: (handler: (event: E, res: Res) => Promise<Ret>) => H;
-  createReactRouterRequest: (event: E) => Request;
+  createReactRouterRequest: (event: E, useRequestContextDomainName?: boolean) => Request;
   sendReactRouterResponse: (nodeResponse: Response, response: Res) => Promise<Ret>;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -53,13 +53,15 @@ export type CreateRequestHandlerArgs<T> = {
    *
    * Use this when the default forwarded host is not the host the browser sees.
    * For example, a Lambda Function URL behind CloudFront cannot use its
-   * request-context domain name (always the internal `*.lambda-url` host) — the
-   * trusted viewer host is forwarded in a header such as `cloudfront-viewer-host`:
+   * request-context domain name (always the internal `*.lambda-url` host), and
+   * CloudFront does not forward the viewer host by default. Forward it yourself
+   * (e.g. a CloudFront Function copying the viewer `Host` into a custom header)
+   * and read that header here:
    *
    * ```ts
    * createFunctionURLRequestHandler({
    *   build,
-   *   getHost: (event) => event.headers["cloudfront-viewer-host"],
+   *   getHost: (event) => event.headers["x-viewer-host"],
    * });
    * ```
    *

--- a/src/server.ts
+++ b/src/server.ts
@@ -64,11 +64,15 @@ export type CreateRequestHandlerArgs<T> = {
    * ```
    *
    * @remarks
-   * The default currently uses the `x-forwarded-host` header. To align with the
-   * upstream `@react-router/architect` adapter, the default will change to the
-   * API Gateway request context domain name (`event.requestContext.domainName`)
-   * in the next major version. Setups where that host is not the browser-facing
-   * host (e.g. Function URLs behind CloudFront) should set `getHost` explicitly.
+   * The default currently uses the `x-forwarded-host` header, which is
+   * client-controlled and can be spoofed. Because that host drives the CSRF
+   * check, trusting it should be deliberate: the default will change to the
+   * AWS-provided, non-spoofable request-context domain name
+   * (`event.requestContext.domainName`) in the next major version (aligning with
+   * the upstream `@react-router/architect` adapter), after which relying on a
+   * forwarded header becomes an explicit opt-in via `getHost`. Setups where the
+   * request-context host is not the browser-facing host (e.g. Function URLs
+   * behind CloudFront) must set `getHost`.
    */
   getHost?: GetHostFunction<T>;
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -40,6 +40,27 @@ export type CreateRequestHandlerArgs<T> = {
   build: ServerBuild;
   getLoadContext?: GetLoadContextFunction<T>;
   mode?: string;
+  /**
+   * Derive the request URL host from the API Gateway request context
+   * (`event.requestContext.domainName`) instead of the client-supplied
+   * `x-forwarded-host` header (falling back to the `host` header in both cases).
+   *
+   * The request URL host is what React Router uses for its built-in cross-origin
+   * (CSRF) check on action requests, so preferring the AWS-provided domain name
+   * avoids trusting a client-influenced header.
+   *
+   * Has no effect for the ALB adapter, whose events carry no request-context
+   * domain name.
+   *
+   * @default false
+   *
+   * @remarks
+   * This mirrors the `@react-router/architect` adapter. To align with React
+   * Router, this option will default to `true` in the next major version, after
+   * which the flag will be removed and the request-context domain name will
+   * always be used.
+   */
+  useRequestContextDomainName?: boolean;
 };
 
 /**
@@ -111,7 +132,12 @@ export function createFunctionURLStreamingRequestHandler(
 
 function createRequestHandlerForAdapter<E, Ret, Res, H>(
   awsAdapter: ReactRouterAdapter<E, Ret, Res, H>,
-  { build, getLoadContext, mode = process.env.NODE_ENV }: CreateRequestHandlerArgs<E>,
+  {
+    build,
+    getLoadContext,
+    mode = process.env.NODE_ENV,
+    useRequestContextDomainName = false,
+  }: CreateRequestHandlerArgs<E>,
 ) {
   const handleRequest = createReactRouterRequestHandler(build, mode);
 
@@ -119,7 +145,7 @@ function createRequestHandlerForAdapter<E, Ret, Res, H>(
     let request: Request;
 
     try {
-      request = awsAdapter.createReactRouterRequest(event);
+      request = awsAdapter.createReactRouterRequest(event, useRequestContextDomainName);
     } catch (e: unknown) {
       return await awsAdapter.sendReactRouterResponse(
         new Response(`Bad Request: ${e instanceof Error ? e.message : e}`, { status: 400 }),

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,7 +17,7 @@ import {
   type UNSAFE_MiddlewareEnabled as MiddlewareEnabled,
 } from "react-router";
 
-import type { ReactRouterAdapter } from "./adapters";
+import type { GetHostFunction, ReactRouterAdapter } from "./adapters";
 import { apiGatewayV1Adapter } from "./adapters/api-gateway-v1";
 import { apiGatewayV2Adapter } from "./adapters/api-gateway-v2";
 import { applicationLoadBalancerAdapter } from "./adapters/application-load-balancer";
@@ -41,26 +41,36 @@ export type CreateRequestHandlerArgs<T> = {
   getLoadContext?: GetLoadContextFunction<T>;
   mode?: string;
   /**
-   * Derive the request URL host from the API Gateway request context
-   * (`event.requestContext.domainName`) instead of the client-supplied
-   * `x-forwarded-host` header (falling back to the `host` header in both cases).
+   * Override how the host for the request URL is derived from the Lambda event.
    *
-   * The request URL host is what React Router uses for its built-in cross-origin
-   * (CSRF) check on action requests, so preferring the AWS-provided domain name
-   * avoids trusting a client-influenced header.
+   * React Router uses the request URL host (`new URL(request.url).host`) for its
+   * built-in cross-origin (CSRF) check on action requests, comparing it against
+   * the incoming `Origin` header. The returned value is sanitized (invalid
+   * characters stripped, port validated) before use.
    *
-   * Has no effect for the ALB adapter, whose events carry no request-context
-   * domain name.
+   * Return `undefined`/`null` to fall back to the default: the
+   * `x-forwarded-host` header (falling back to the `host`/`Host` header).
    *
-   * @default false
+   * Use this when the default forwarded host is not the host the browser sees.
+   * For example, a Lambda Function URL behind CloudFront cannot use its
+   * request-context domain name (always the internal `*.lambda-url` host) — the
+   * trusted viewer host is forwarded in a header such as `cloudfront-viewer-host`:
+   *
+   * ```ts
+   * createFunctionURLRequestHandler({
+   *   build,
+   *   getHost: (event) => event.headers["cloudfront-viewer-host"],
+   * });
+   * ```
    *
    * @remarks
-   * This mirrors the `@react-router/architect` adapter. To align with React
-   * Router, this option will default to `true` in the next major version, after
-   * which the flag will be removed and the request-context domain name will
-   * always be used.
+   * The default currently uses the `x-forwarded-host` header. To align with the
+   * upstream `@react-router/architect` adapter, the default will change to the
+   * API Gateway request context domain name (`event.requestContext.domainName`)
+   * in the next major version. Setups where that host is not the browser-facing
+   * host (e.g. Function URLs behind CloudFront) should set `getHost` explicitly.
    */
-  useRequestContextDomainName?: boolean;
+  getHost?: GetHostFunction<T>;
 };
 
 /**
@@ -132,12 +142,7 @@ export function createFunctionURLStreamingRequestHandler(
 
 function createRequestHandlerForAdapter<E, Ret, Res, H>(
   awsAdapter: ReactRouterAdapter<E, Ret, Res, H>,
-  {
-    build,
-    getLoadContext,
-    mode = process.env.NODE_ENV,
-    useRequestContextDomainName = false,
-  }: CreateRequestHandlerArgs<E>,
+  { build, getLoadContext, mode = process.env.NODE_ENV, getHost }: CreateRequestHandlerArgs<E>,
 ) {
   const handleRequest = createReactRouterRequestHandler(build, mode);
 
@@ -145,7 +150,7 @@ function createRequestHandlerForAdapter<E, Ret, Res, H>(
     let request: Request;
 
     try {
-      request = awsAdapter.createReactRouterRequest(event, useRequestContextDomainName);
+      request = awsAdapter.createReactRouterRequest(event, getHost);
     } catch (e: unknown) {
       return await awsAdapter.sendReactRouterResponse(
         new Response(`Bad Request: ${e instanceof Error ? e.message : e}`, { status: 400 }),

--- a/test/alb.test.ts
+++ b/test/alb.test.ts
@@ -43,6 +43,21 @@ describe("ALB request handling", () => {
       albEvent("/test", "GET", { "x-forwarded-host": "example.com:4444/invalid@chars" }),
     );
   });
+
+  it("uses getHost when provided", async () => {
+    await invokeHandlerWithRRMock(
+      "createALBRequestHandler",
+      async (request: Request) => {
+        expect(request.url).toBe("https://viewer.example.com/test");
+        return new Response("ok");
+      },
+      albEvent("/test", "GET", {
+        "x-forwarded-host": "forwarded.example.com",
+        "x-trusted-host": "viewer.example.com",
+      }),
+      { getHost: (event) => event.headers?.["x-trusted-host"] },
+    );
+  });
 });
 
 describe("ALB response handling", () => {

--- a/test/alb.test.ts
+++ b/test/alb.test.ts
@@ -32,6 +32,17 @@ describe("ALB request handling", () => {
       albEvent("/test", "POST", { "x-custom-header": "a" }),
     );
   });
+
+  it("strips invalid characters from the host", async () => {
+    await invokeHandlerWithRRMock(
+      "createALBRequestHandler",
+      async (request: Request) => {
+        expect(request.url).toBe("https://example.com:4444/test");
+        return new Response("ok");
+      },
+      albEvent("/test", "GET", { "x-forwarded-host": "example.com:4444/invalid@chars" }),
+    );
+  });
 });
 
 describe("ALB response handling", () => {

--- a/test/apigw-v1.test.ts
+++ b/test/apigw-v1.test.ts
@@ -48,7 +48,7 @@ describe("API Gateway v1 request handling", () => {
     );
   });
 
-  it("uses the request context domain name when enabled", async () => {
+  it("uses getHost when provided", async () => {
     await invokeHandlerWithRRMock(
       "createAPIGatewayV1RequestHandler",
       (request) => {
@@ -56,7 +56,19 @@ describe("API Gateway v1 request handling", () => {
         return new Response("ok");
       },
       apiGatewayV1Event("/test", "GET", { "x-forwarded-host": "forwarded.example.com" }, "context.example.com"),
-      { useRequestContextDomainName: true },
+      { getHost: (event) => event.requestContext.domainName },
+    );
+  });
+
+  it("falls back to x-forwarded-host when getHost returns undefined", async () => {
+    await invokeHandlerWithRRMock(
+      "createAPIGatewayV1RequestHandler",
+      (request) => {
+        expect(request.url).toBe("https://forwarded.example.com/test");
+        return new Response("ok");
+      },
+      apiGatewayV1Event("/test", "GET", { "x-forwarded-host": "forwarded.example.com" }, "context.example.com"),
+      { getHost: () => undefined },
     );
   });
 

--- a/test/apigw-v1.test.ts
+++ b/test/apigw-v1.test.ts
@@ -3,9 +3,14 @@ import { describe, it, expect } from "vitest";
 
 import { htmlResponse, redirectResponse, invokeHandlerWithRRMock } from "./utils";
 
-function apiGatewayV1Event(path: string, method = "GET", headers: Record<string, string> = {}): APIGatewayProxyEvent {
+function apiGatewayV1Event(
+  path: string,
+  method = "GET",
+  headers: Record<string, string> = {},
+  domainName?: string,
+): APIGatewayProxyEvent {
   return {
-    requestContext: { httpMethod: method } as APIGatewayProxyEvent["requestContext"],
+    requestContext: { httpMethod: method, domainName } as APIGatewayProxyEvent["requestContext"],
     path,
     queryStringParameters: {},
     headers: {
@@ -29,6 +34,40 @@ describe("API Gateway v1 request handling", () => {
         return new Response("ok");
       },
       apiGatewayV1Event("/test", "POST", { "x-custom-header": "a" }),
+    );
+  });
+
+  it("uses x-forwarded-host by default", async () => {
+    await invokeHandlerWithRRMock(
+      "createAPIGatewayV1RequestHandler",
+      (request) => {
+        expect(request.url).toBe("https://forwarded.example.com/test");
+        return new Response("ok");
+      },
+      apiGatewayV1Event("/test", "GET", { "x-forwarded-host": "forwarded.example.com" }, "context.example.com"),
+    );
+  });
+
+  it("uses the request context domain name when enabled", async () => {
+    await invokeHandlerWithRRMock(
+      "createAPIGatewayV1RequestHandler",
+      (request) => {
+        expect(request.url).toBe("https://context.example.com/test");
+        return new Response("ok");
+      },
+      apiGatewayV1Event("/test", "GET", { "x-forwarded-host": "forwarded.example.com" }, "context.example.com"),
+      { useRequestContextDomainName: true },
+    );
+  });
+
+  it("strips invalid characters from the host", async () => {
+    await invokeHandlerWithRRMock(
+      "createAPIGatewayV1RequestHandler",
+      (request) => {
+        expect(request.url).toBe("https://example.com:4444/test");
+        return new Response("ok");
+      },
+      apiGatewayV1Event("/test", "GET", { "x-forwarded-host": "example.com:4444/invalid@chars" }),
     );
   });
 });

--- a/test/apigw-v2.test.ts
+++ b/test/apigw-v2.test.ts
@@ -8,9 +8,10 @@ function apiGatewayV2Event(
   method = "GET",
   headers: Record<string, string> = {},
   cookies?: string[],
+  domainName?: string,
 ): APIGatewayProxyEventV2 {
   return {
-    requestContext: { http: { method } } as APIGatewayProxyEventV2["requestContext"],
+    requestContext: { http: { method }, domainName } as APIGatewayProxyEventV2["requestContext"],
     rawPath: path,
     rawQueryString: "",
     headers: {
@@ -35,6 +36,64 @@ describe("API Gateway v2 request handling", () => {
         return new Response("ok");
       },
       apiGatewayV2Event("/test", "POST", { "x-custom-header": "a" }),
+    );
+  });
+
+  it("uses x-forwarded-host by default", async () => {
+    await invokeHandlerWithRRMock(
+      "createAPIGatewayV2RequestHandler",
+      (request) => {
+        expect(request.url).toBe("https://forwarded.example.com/test");
+        return new Response("ok");
+      },
+      apiGatewayV2Event(
+        "/test",
+        "GET",
+        { "x-forwarded-host": "forwarded.example.com" },
+        undefined,
+        "context.example.com",
+      ),
+    );
+  });
+
+  it("uses the request context domain name when enabled", async () => {
+    await invokeHandlerWithRRMock(
+      "createAPIGatewayV2RequestHandler",
+      (request) => {
+        expect(request.url).toBe("https://context.example.com/test");
+        return new Response("ok");
+      },
+      apiGatewayV2Event(
+        "/test",
+        "GET",
+        { "x-forwarded-host": "forwarded.example.com" },
+        undefined,
+        "context.example.com",
+      ),
+      { useRequestContextDomainName: true },
+    );
+  });
+
+  it("falls back to the host header when the request context domain name is missing", async () => {
+    await invokeHandlerWithRRMock(
+      "createAPIGatewayV2RequestHandler",
+      (request) => {
+        expect(request.url).toBe("https://example.com/test");
+        return new Response("ok");
+      },
+      apiGatewayV2Event("/test", "GET", { "x-forwarded-host": "forwarded.example.com" }),
+      { useRequestContextDomainName: true },
+    );
+  });
+
+  it("strips invalid characters from the host", async () => {
+    await invokeHandlerWithRRMock(
+      "createAPIGatewayV2RequestHandler",
+      (request) => {
+        expect(request.url).toBe("https://example.com:4444/test");
+        return new Response("ok");
+      },
+      apiGatewayV2Event("/test", "GET", { "x-forwarded-host": "example.com:4444/invalid@chars" }),
     );
   });
 });

--- a/test/apigw-v2.test.ts
+++ b/test/apigw-v2.test.ts
@@ -56,7 +56,7 @@ describe("API Gateway v2 request handling", () => {
     );
   });
 
-  it("uses the request context domain name when enabled", async () => {
+  it("uses getHost when provided (request context domain name)", async () => {
     await invokeHandlerWithRRMock(
       "createAPIGatewayV2RequestHandler",
       (request) => {
@@ -70,19 +70,34 @@ describe("API Gateway v2 request handling", () => {
         undefined,
         "context.example.com",
       ),
-      { useRequestContextDomainName: true },
+      { getHost: (event) => event.requestContext.domainName },
     );
   });
 
-  it("falls back to the host header when the request context domain name is missing", async () => {
+  it("uses getHost when provided (custom forwarded header)", async () => {
     await invokeHandlerWithRRMock(
       "createAPIGatewayV2RequestHandler",
       (request) => {
-        expect(request.url).toBe("https://example.com/test");
+        expect(request.url).toBe("https://viewer.example.com/test");
+        return new Response("ok");
+      },
+      apiGatewayV2Event("/test", "GET", {
+        "x-forwarded-host": "forwarded.example.com",
+        "cloudfront-viewer-host": "viewer.example.com",
+      }),
+      { getHost: (event) => event.headers["cloudfront-viewer-host"] },
+    );
+  });
+
+  it("falls back to x-forwarded-host when getHost returns undefined", async () => {
+    await invokeHandlerWithRRMock(
+      "createAPIGatewayV2RequestHandler",
+      (request) => {
+        expect(request.url).toBe("https://forwarded.example.com/test");
         return new Response("ok");
       },
       apiGatewayV2Event("/test", "GET", { "x-forwarded-host": "forwarded.example.com" }),
-      { useRequestContextDomainName: true },
+      { getHost: () => undefined },
     );
   });
 

--- a/test/apigw-v2.test.ts
+++ b/test/apigw-v2.test.ts
@@ -83,9 +83,9 @@ describe("API Gateway v2 request handling", () => {
       },
       apiGatewayV2Event("/test", "GET", {
         "x-forwarded-host": "forwarded.example.com",
-        "cloudfront-viewer-host": "viewer.example.com",
+        "x-viewer-host": "viewer.example.com",
       }),
-      { getHost: (event) => event.headers["cloudfront-viewer-host"] },
+      { getHost: (event) => event.headers["x-viewer-host"] },
     );
   });
 

--- a/test/host.test.ts
+++ b/test/host.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { resolveHost } from "../src/adapters/host";
 
 describe("resolveHost", () => {

--- a/test/host.test.ts
+++ b/test/host.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { resolveHost } from "../src/adapters/host";
+
+describe("resolveHost", () => {
+  it("returns a plain hostname unchanged", () => {
+    expect(resolveHost("example.com")).toBe("example.com");
+  });
+
+  it("keeps a valid port", () => {
+    expect(resolveHost("example.com:8443")).toBe("example.com:8443");
+  });
+
+  it("falls back to localhost for missing values", () => {
+    expect(resolveHost(undefined)).toBe("localhost");
+    expect(resolveHost(null)).toBe("localhost");
+    expect(resolveHost("")).toBe("localhost");
+  });
+
+  it("drops a non-numeric port", () => {
+    expect(resolveHost("example.com:notaport")).toBe("example.com");
+  });
+
+  it("strips invalid characters from the hostname", () => {
+    expect(resolveHost("example.com/path")).toBe("example.com");
+    expect(resolveHost("user@example.com")).toBe("user");
+    expect(resolveHost("example.com:4444/invalid@chars")).toBe("example.com:4444");
+  });
+
+  it("falls back to localhost when the hostname is only invalid characters", () => {
+    expect(resolveHost("#invalid")).toBe("localhost");
+  });
+});

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -29,21 +29,25 @@ type GatewayHandlers = Pick<
 
 type RRHandler = (request: Request) => Response | Promise<Response>;
 
+type HandlerOptions = { useRequestContextDomainName?: boolean };
+
 export async function createHandlerWithRRMock<T extends keyof GatewayHandlers>(
   gatewayHandler: T,
   handler: RRHandler,
+  options: HandlerOptions = {},
 ): Promise<GatewayHandlers[T]> {
   setReactRouterHandler(handler);
   const handlerFactory = (await import("../src"))[gatewayHandler] as any;
-  return handlerFactory({ build: {} as unknown as ServerBuild });
+  return handlerFactory({ build: {} as unknown as ServerBuild, ...options });
 }
 
 export async function invokeHandlerWithRRMock<T extends keyof GatewayHandlers>(
   gatewayHandler: T,
   rrHandler: RRHandler,
   event: Parameters<ReturnType<GatewayHandlers[T]>>[0],
+  options: HandlerOptions = {},
 ) {
-  const handler = await createHandlerWithRRMock(gatewayHandler, rrHandler);
+  const handler = await createHandlerWithRRMock(gatewayHandler, rrHandler, options);
   return invokeHandler(handler as any, event);
 }
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -29,12 +29,16 @@ type GatewayHandlers = Pick<
 
 type RRHandler = (request: Request) => Response | Promise<Response>;
 
-type HandlerOptions = { useRequestContextDomainName?: boolean };
+type GatewayEvent<T extends keyof GatewayHandlers> = Parameters<ReturnType<GatewayHandlers[T]>>[0];
+
+type HandlerOptions<T extends keyof GatewayHandlers> = {
+  getHost?: (event: GatewayEvent<T>) => string | null | undefined;
+};
 
 export async function createHandlerWithRRMock<T extends keyof GatewayHandlers>(
   gatewayHandler: T,
   handler: RRHandler,
-  options: HandlerOptions = {},
+  options: HandlerOptions<T> = {},
 ): Promise<GatewayHandlers[T]> {
   setReactRouterHandler(handler);
   const handlerFactory = (await import("../src"))[gatewayHandler] as any;
@@ -44,8 +48,8 @@ export async function createHandlerWithRRMock<T extends keyof GatewayHandlers>(
 export async function invokeHandlerWithRRMock<T extends keyof GatewayHandlers>(
   gatewayHandler: T,
   rrHandler: RRHandler,
-  event: Parameters<ReturnType<GatewayHandlers[T]>>[0],
-  options: HandlerOptions = {},
+  event: GatewayEvent<T>,
+  options: HandlerOptions<T> = {},
 ) {
   const handler = await createHandlerWithRRMock(gatewayHandler, rrHandler, options);
   return invokeHandler(handler as any, event);


### PR DESCRIPTION
## Summary

Ports the relevant parts of upstream [react-router#15185](https://github.com/remix-run/react-router/pull/15185) (shipped in `react-router@7.18.0`) into our adapters, and gives users control over the host React Router uses for its built-in cross-origin (CSRF) check.

In #15185, React Router's CSRF check stopped parsing `x-forwarded-host`/`host` itself and now compares the `Origin` header against `new URL(request.url).host`. That makes the **adapter-constructed request URL host the single source of truth for CSRF**, so it must be trustworthy and well-formed.

This PR has two parts:

**1. `getHost` option** — a callback to derive the request host from the event, replacing the original `useRequestContextDomainName` boolean.

A boolean only fit the "API Gateway custom domain" topology that the upstream architect adapter assumes. It is actively wrong for a **Lambda Function URL behind CloudFront** (a setup we use): `event.requestContext.domainName` is always the internal `*.lambda-url.<region>.on.aws` host and cannot be overridden, so using it would make CSRF compare the viewer's `Origin` (the public CloudFront domain) against the function URL → every action request fails. The trusted viewer host must instead come from a header you forward.

The callback is general and typed per gateway:

```ts
// default (no getHost): x-forwarded-host || host  — unchanged
createFunctionURLRequestHandler({
  build,
  getHost: (event) => event.headers["x-viewer-host"], // a header you forward the viewer host in
});
// or, to mirror upstream architect:
getHost: (event) => event.requestContext.domainName;
```

- Threaded through `CreateRequestHandlerArgs<T>` → each adapter's `createReactRouterRequest(event, getHost?)`.
- `getHost` returning `undefined`/`null` falls back to the default (`x-forwarded-host || host`). Its result is always passed through `resolveHost` (hardening below).
- Supported by **all** handlers including ALB (the old boolean was a no-op for ALB).

**2. Host hardening** — shared `resolveHost` helper (`src/adapters/host.ts`) used by all adapters, mirroring upstream:

```ts
const [rawHostname = "", portStr] = (rawHost ?? "").split(":");
const hostname = rawHostname.split(/[\\/?#@]/)[0] || "localhost";
const hostPort = Number.parseInt(portStr ?? "", 10);
const port = Number.isSafeInteger(hostPort) ? hostPort : undefined;
return `${hostname}${port ? `:${port}` : ""}`;
```

For any valid host this is byte-for-byte identical; only malformed/missing hosts change behavior (fall back to `localhost` / drop a non-numeric port instead of throwing → 400).

### Peer dependency

Raised the `react-router` and `@react-router/node` **peer floor to `^7.18.0`** (devDependencies + lockfile updated to match), since that is the release where the CSRF host behavior this PR targets takes effect. This mirrors `@react-router/architect`, which bumps its peer to its own version each minor release (7.17.0 → `^7.17.0`, 7.18.0 → `^7.18.0`) and stays a minor — so this PR remains labeled `minor`.

### Notes
- **Not a behavior change by default**: `getHost` is opt-in and the default (`x-forwarded-host || host`) is unchanged; host hardening only affects already-malformed inputs.
- The current default (`x-forwarded-host`) is client-controlled/spoofable. Per discussion, the default will switch to the non-spoofable `event.requestContext.domainName` in the **next major** (aligning with `@react-router/architect`), after which relying on any forwarded header becomes an explicit `getHost` opt-in. Documented in the README and the option's TSDoc.
- **CloudFront note**: there is no `CloudFront-Viewer-Host` header. With a Function URL origin you'd use the managed `AllViewerExceptHostHeader` policy (which sets `Host` to the origin domain), so the viewer host must be forwarded yourself — e.g. a CloudFront Function copying the viewer `Host` into a custom header read via `getHost` (or into `x-forwarded-host`, in which case the default already works). The README documents this.
- Did **not** port comma-splitting of `x-forwarded-host` (upstream architect dropped it too), nor the core `actions.ts`/`@react-router/express` changes (internal/irrelevant here).
- Rebased onto the new pnpm/tsdown/oxlint/oxfmt tooling on `main`.

### Tests
- `test/host.test.ts` unit-tests `resolveHost`.
- `getHost` request-handling tests for v1/v2/ALB (custom header + request-context domain + fallback) and host-hardening tests; test utils now type `getHost` per gateway event.
- `lint`, `format:check`, `typecheck`, `build` (tsdown) and `test` (42 passing) all green.

Link to Devin session: https://app.devin.ai/sessions/6ab204f90df8472e9f5be5b6d6241cbc
Requested by: @oxc
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/geostrategists/react-router-aws/pull/11" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->