### PR TITLE
chore: group release notes into titled changelog categories

### DIFF
--- a/.github/release-drafter-prerelease.yml
+++ b/.github/release-drafter-prerelease.yml
@@ -4,17 +4,17 @@ tag-template: 'v$RESOLVED_VERSION'
 prerelease: true
 prerelease-identifier: rc
 categories:
-  - type: version-resolver
+  - title: "💥 Breaking Changes"
     semver-increment: major
     when:
       labels:
         - major
-  - type: version-resolver
+  - title: "🚀 Features"
     semver-increment: minor
     when:
       labels:
         - minor
-  - type: version-resolver
+  - title: "🐛 Bug Fixes & Improvements"
     semver-increment: patch
     when:
       labels:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,17 +2,17 @@
 name-template: 'v$RESOLVED_VERSION 🌈'
 tag-template: 'v$RESOLVED_VERSION'
 categories:
-  - type: version-resolver
+  - title: "💥 Breaking Changes"
     semver-increment: major
     when:
       labels:
         - major
-  - type: version-resolver
+  - title: "🚀 Features"
     semver-increment: minor
     when:
       labels:
         - minor
-  - type: version-resolver
+  - title: "🐛 Bug Fixes & Improvements"
     semver-increment: patch
     when:
       labels:


### PR DESCRIPTION
## Summary

Gives this repo's drafted release notes the same grouped headings as the portal repos, instead of one flat `$CHANGES` list. The three labeled `version-resolver` categories become titled changelog categories (keeping their `semver-increment` + `when`); the default-patch resolver and `pre-exclude` are untouched. Applied to both `release-drafter.yml` and `release-drafter-prerelease.yml`.

```diff
 categories:
-  - type: version-resolver
-    semver-increment: major
-    when: { labels: [major] }
-  - type: version-resolver
-    semver-increment: minor
-    when: { labels: [minor] }
-  - type: version-resolver
-    semver-increment: patch
-    when: { labels: [patch] }
+  - title: "💥 Breaking Changes"
+    semver-increment: major
+    when: { labels: [major] }
+  - title: "🚀 Features"
+    semver-increment: minor
+    when: { labels: [minor] }
+  - title: "🐛 Bug Fixes & Improvements"
+    semver-increment: patch
+    when: { labels: [patch] }
   - { type: version-resolver, semver-increment: patch }   # default
   - { type: pre-exclude, when: { labels: [ignore-for-release] } }
```

Version resolution is unchanged (titled categories still carry `semver-increment`); only the notes layout changes — PRs are now grouped under the three headings. Trial run for the public/library repos; once you're happy I'll copy it to react-router-sessions-dynamodb, cdk-jwks-rotation, and hamstore.

Link to Devin session: https://app.devin.ai/sessions/3bdfc4e1eef54b07af2479fdcd73e0f3
Requested by: @oxc