### PR TITLE
chore: collect uncategorized PRs into a bottom "Other Changes" section

### DIFF
--- a/.github/release-drafter-prerelease.yml
+++ b/.github/release-drafter-prerelease.yml
@@ -19,7 +19,7 @@ categories:
     when:
       labels:
         - patch
-  - title: "📝 Other Changes"
+  - title: "📝 Documentation & Other Changes"
   - type: version-resolver
     semver-increment: patch
   - type: pre-exclude

--- a/.github/release-drafter-prerelease.yml
+++ b/.github/release-drafter-prerelease.yml
@@ -19,6 +19,7 @@ categories:
     when:
       labels:
         - patch
+  - title: "📝 Other Changes"
   - type: version-resolver
     semver-increment: patch
   - type: pre-exclude

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -17,7 +17,7 @@ categories:
     when:
       labels:
         - patch
-  - title: "📝 Other Changes"
+  - title: "📝 Documentation & Other Changes"
   - type: version-resolver
     semver-increment: patch
   - type: pre-exclude

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -17,6 +17,7 @@ categories:
     when:
       labels:
         - patch
+  - title: "📝 Other Changes"
   - type: version-resolver
     semver-increment: patch
   - type: pre-exclude


### PR DESCRIPTION
## Summary

Follow-up to #15. Uncategorized PRs (anything the autolabeler doesn't tag `major`/`minor`/`patch` — e.g. `chore`/`docs`/`refactor`) currently render as an untitled block at the **top** of the drafted notes. This adds a title-only catch-all changelog category so they collect under "📝 Documentation & Other Changes" at the **bottom** instead. Applied to both `release-drafter.yml` and `release-drafter-prerelease.yml`.

```diff
   - title: "🐛 Bug Fixes & Improvements"
     semver-increment: patch
     when: { labels: [patch] }
+  - title: "📝 Documentation & Other Changes"   # catch-all (no when:) -> renders last
   - { type: version-resolver, semver-increment: patch }
   - { type: pre-exclude, when: { labels: [ignore-for-release] } }
```

A changelog category with an empty `when` is release-drafter's documented bucket for uncategorized PRs (`categorize-pull-requests.ts` routes non-matching PRs to the category whose `when.length === 0`; without one they're emitted at the top by `generate-changelog.ts`). A title-only category normalizes to `when: []` (`parse-categories.ts`). No `semver-increment` here — it's display-only; the trailing default-patch `version-resolver` still drives versioning. Title chosen so notes read naturally even when a release contains only docs/chore changes.

Link to Devin session: https://app.devin.ai/sessions/3bdfc4e1eef54b07af2479fdcd73e0f3
Requested by: @oxc
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/geostrategists/react-router-aws/pull/17" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->